### PR TITLE
core: centralize simulation constants

### DIFF
--- a/src/components/Components.hpp
+++ b/src/components/Components.hpp
@@ -3,6 +3,8 @@
 #include <raylib-cpp.hpp>
 #include <vector>
 
+#include "../core/Constants.hpp"
+
 // Basic physics/render components
 struct Position {
     raylib::Vector2 value;
@@ -42,7 +44,7 @@ struct Selected {
 
 struct Draggable {
     bool canDragVelocity = true;
-    float dragScale = 0.01f;
+    float dragScale = nbody::constants::dragVelScale;
 };
 
 // (removed) MouseInteraction: legacy input state no longer used

--- a/src/core/Constants.hpp
+++ b/src/core/Constants.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <raylib.h>
+
+namespace nbody::constants {
+    inline constexpr int windowWidth = 1280;
+    inline constexpr int windowHeight = 720;
+    inline constexpr int targetFps = 120;
+
+    inline constexpr ::Color background{10, 10, 14, 255};
+
+    inline constexpr float pickRadiusPx = 24.0F;
+    inline constexpr float selectThresholdSq = 9.0F;
+    inline constexpr float dragVelScale = 0.01F;
+
+    inline constexpr float dragLineWidth = 2.0F;
+    inline constexpr float dragCircleRadius = 3.0F;
+    inline constexpr float ringExtraRadius = 4.0F;
+    inline constexpr float ringThickness = 3.5F;
+    inline constexpr float ringInnerOffset = 2.0F;
+    inline constexpr float ringStartAngle = 0.0F;
+    inline constexpr float ringEndAngle = 360.0F;
+    inline constexpr int ringSegments = 32;
+    inline constexpr float velLineWidth = 1.5F;
+    inline constexpr float accLineWidth = 1.0F;
+    inline constexpr float velVectorScale = 10.0F;
+    inline constexpr float accVectorScale = 500.0F;
+    inline constexpr float minBodyRadius = 6.0F;
+    inline constexpr float selectedCircleAlpha = 0.5F;
+
+    inline constexpr float gridSpacing = 50.0F;
+    inline constexpr float gridAxisEpsilon = 1e-4F;
+    inline constexpr float gridStepsEpsilon = 1e-6F;
+    inline constexpr ::Color gridColor{40, 40, 40, 255};
+    inline constexpr ::Color axisColor{80, 80, 80, 255};
+
+    inline constexpr int trailAlphaMin = 20;
+    inline constexpr int trailAlphaMax = 250;
+    inline constexpr float trailAlphaRange = 230.0F;
+
+    inline constexpr float seedSmallMass = 12.0F;
+    inline constexpr float seedCentralMass = 4000.0F;
+    inline constexpr float seedSpeed = 1.20F;
+    inline constexpr float seedCenterX = 640.0F;
+    inline constexpr float seedCenterY = 360.0F;
+    inline constexpr float seedOffsetX = 200.0F;
+
+    inline constexpr float zoomWheelScale = 0.1F;
+    inline constexpr float minZoom = 0.05F;
+    inline constexpr float maxZoom = 10.0F;
+
+    inline constexpr float fixedDtMin = 1e-4F;
+    inline constexpr float fixedDtMax = 0.05F;
+    inline constexpr float timeScaleMin = 0.0F;
+    inline constexpr float timeScaleMax = 10.0F;
+    inline constexpr float gMin = 0.0F;
+    inline constexpr float gMax = 0.02F;
+    inline constexpr float softeningMin = 0.0F;
+    inline constexpr float softeningMax = 20.0F;
+    inline constexpr float velocityCapMin = 0.0F;
+    inline constexpr float velocityCapMax = 200.0F;
+    inline constexpr int trailLengthMax = 2000;
+
+    inline constexpr float spawnMassMin = 1.0F;
+    inline constexpr float spawnMassMax = 5000.0F;
+    inline constexpr float spawnVelMin = -5.0F;
+    inline constexpr float spawnVelMax = 5.0F;
+    inline constexpr float dragVelScaleMin = 0.001F;
+    inline constexpr float dragVelScaleMax = 0.2F;
+    inline constexpr float selectedMassMin = 1.0F;
+    inline constexpr float selectedMassMax = 10000.0F;
+    inline constexpr float selectedVelMin = -200.0F;
+    inline constexpr float selectedVelMax = 200.0F;
+    inline constexpr float duplicateOffsetX = 20.0F;
+
+    inline constexpr int randomColorMin = 64;
+    inline constexpr int randomColorMax = 255;
+}  // namespace nbody::constants

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 
 #include "components/Components.hpp"
 #include "core/Config.hpp"
+#include "core/Constants.hpp"
 
 // New header-only systems
 #include "systems/Camera.hpp"
@@ -16,37 +17,6 @@
 #include "systems/Physics.hpp"
 #include "systems/Render.hpp"
 #include "systems/UI.hpp"
-
-namespace constants {
-    // Window and timing
-    constexpr int window_width = 1280;
-    constexpr int window_height = 720;
-    constexpr int target_fps = 120;
-
-    // Background color
-    constexpr ::Color background{10, 10, 14, 255};
-
-    // Picking and dragging
-    constexpr float pick_radius_px = 24.0F;  // screen-space pick radius before zoom scaling
-    constexpr float select_threshold_sq = 9.0F;  // squared pixel drag threshold to treat as click
-    constexpr float drag_vel_scale = 0.01F;  // scale from drag vector to velocity
-
-    // Visual thickness/radii
-    constexpr float drag_line_width = 2.0F;
-    constexpr float drag_circle_radius = 3.0F;
-    constexpr float ring_extra_radius = 4.0F;
-    constexpr float ring_thickness = 3.5F;
-    [[maybe_unused]] constexpr float vel_line_width = 1.5F;
-    [[maybe_unused]] constexpr float acc_line_width = 1.0F;
-
-    // Seed scenario
-    constexpr float seed_small_mass = 12.0F;
-    constexpr float seed_central_mass = 4000.0F;
-    constexpr float seed_speed = 1.20F;
-    constexpr float seed_center_x = 640.0F;
-    constexpr float seed_center_y = 360.0F;
-    constexpr float seed_offset_x = 200.0F;  // +/- from center for initial bodies
-}  // namespace constants
 
 namespace scenario {
     void CreateInitialBodies(const flecs::world& world) {
@@ -63,15 +33,15 @@ namespace scenario {
                 .set<Tint>({col})
                 .set<Trail>({{}})
                 .add<Selectable>()  // Make all bodies selectable
-                .set<Draggable>({true, constants::drag_vel_scale});  // Make all bodies draggable
+                .set<Draggable>({true, nbody::constants::dragVelScale});  // Make all bodies draggable
         };
 
-        mk({constants::seed_center_x, constants::seed_center_y}, {0.0f, 0.0f}, constants::seed_central_mass, RED,
-           false);
-        mk({constants::seed_center_x + constants::seed_offset_x, constants::seed_center_y},
-           {0.0f, constants::seed_speed}, constants::seed_small_mass, BLUE, false);
-        mk({constants::seed_center_x - constants::seed_offset_x, constants::seed_center_y},
-           {0.0f, -constants::seed_speed}, constants::seed_small_mass, GREEN, false);
+        mk({nbody::constants::seedCenterX, nbody::constants::seedCenterY}, {0.0f, 0.0f},
+           nbody::constants::seedCentralMass, RED, false);
+        mk({nbody::constants::seedCenterX + nbody::constants::seedOffsetX, nbody::constants::seedCenterY},
+           {0.0f, nbody::constants::seedSpeed}, nbody::constants::seedSmallMass, BLUE, false);
+        mk({nbody::constants::seedCenterX - nbody::constants::seedOffsetX, nbody::constants::seedCenterY},
+           {0.0f, -nbody::constants::seedSpeed}, nbody::constants::seedSmallMass, GREEN, false);
     }
 }  // namespace scenario
 
@@ -80,8 +50,8 @@ public:
     Application() {
         SetConfigFlags(FLAG_WINDOW_HIGHDPI | FLAG_MSAA_4X_HINT);
         // Initialize window after setting flags
-        InitWindow(constants::window_width, constants::window_height, "N-Body Gravity Simulation • ECS");
-        SetTargetFPS(constants::target_fps);
+        InitWindow(nbody::constants::windowWidth, nbody::constants::windowHeight, "N-Body Gravity Simulation • ECS");
+        SetTargetFPS(nbody::constants::targetFps);
         rlImGuiSetup(true);
 
         InitializeWorld();
@@ -162,7 +132,7 @@ private:
 
     void Render() {
         BeginDrawing();
-        ClearBackground(constants::background);
+        ClearBackground(nbody::constants::background);
 
         // Get camera for rendering
         raylib::Camera2D* camera = nbody::Camera::Get(world_);

--- a/src/systems/Camera.hpp
+++ b/src/systems/Camera.hpp
@@ -6,6 +6,7 @@
 #include <raymath.h>
 
 #include "../components/Components.hpp"
+#include "../core/Constants.hpp"
 
 namespace nbody {
 
@@ -16,17 +17,15 @@ namespace nbody {
             constexpr float kHalf = 0.5F;
             cam.zoom = 1.0F;
             cam.offset = {static_cast<float>(GetScreenWidth()) * kHalf, static_cast<float>(GetScreenHeight()) * kHalf};
-            cam.target = {640.0F, 360.0F};
+            cam.target = {nbody::constants::seedCenterX, nbody::constants::seedCenterY};
         }
 
         static inline void ZoomAtMouse(raylib::Camera2D& cam, const float wheel) {
             if (wheel == 0.0F) return;
             const raylib::Vector2 mouse = GetMousePosition();
             const raylib::Vector2 worldBefore = GetScreenToWorld2D(mouse, cam);
-            constexpr float kWheelScale = 0.1F;
-            constexpr float kMinZoom = 0.05F;
-            constexpr float kMaxZoom = 10.0F;
-            const float newZoom = std::clamp(cam.zoom * (1.0F + wheel * kWheelScale), kMinZoom, kMaxZoom);
+            const float newZoom = std::clamp(cam.zoom * (1.0F + wheel * nbody::constants::zoomWheelScale),
+                                             nbody::constants::minZoom, nbody::constants::maxZoom);
             cam.zoom = newZoom;
             const raylib::Vector2 worldAfter = GetScreenToWorld2D(mouse, cam);
             cam.target = Vector2Add(cam.target, Vector2Subtract(worldBefore, worldAfter));

--- a/src/systems/Render.hpp
+++ b/src/systems/Render.hpp
@@ -8,68 +8,74 @@
 
 #include "../components/Components.hpp"
 #include "../core/Config.hpp"
+#include "../core/Constants.hpp"
 
 namespace nbody {
 
-class Renderer {
-public:
-    static void RenderScene(const flecs::world& w, const Config& cfg, raylib::Camera2D& cam) {
-        cam.BeginMode();
-        DrawWorldGrid(cam, 50.0f);
+    class Renderer {
+    public:
+        static void RenderScene(const flecs::world& w, const Config& cfg, raylib::Camera2D& cam) {
+            cam.BeginMode();
+            DrawWorldGrid(cam, nbody::constants::gridSpacing);
 
-        if (cfg.drawTrails) {
-            w.each([&](const Trail& t, const Tint& tint) {
-                for (size_t k = 1; k < t.points.size(); ++k) {
-                    Color c = tint.value;
-                    const double denom = std::max(1.0, static_cast<double>(t.points.size()));
-                    c.a = static_cast<unsigned char>(
-                        std::clamp(20 + static_cast<int>(230.0 * static_cast<double>(k) / denom), 20, 250));
-                    DrawLineV(t.points[k - 1], t.points[k], c);
+            if (cfg.drawTrails) {
+                w.each([&](const Trail& t, const Tint& tint) {
+                    for (size_t k = 1; k < t.points.size(); ++k) {
+                        Color c = tint.value;
+                        const double denom = std::max(1.0, static_cast<double>(t.points.size()));
+                        c.a = static_cast<unsigned char>(std::clamp(
+                            nbody::constants::trailAlphaMin +
+                                static_cast<int>(nbody::constants::trailAlphaRange * static_cast<double>(k) / denom),
+                            nbody::constants::trailAlphaMin, nbody::constants::trailAlphaMax));
+                        DrawLineV(t.points[k - 1], t.points[k], c);
+                    }
+                });
+            }
+
+            w.each([&](const Position& p, const Velocity& v, const Acceleration& a, const Mass& m, const Tint& tint) {
+                const float r = static_cast<float>(std::cbrt(std::max(1.0, static_cast<double>(m.value))));
+                DrawCircleV(p.value, r, tint.value);
+                if (cfg.drawVelocity) {
+                    const raylib::Vector2 tip = p.value + v.value * nbody::constants::velVectorScale;
+                    DrawLineEx(p.value, tip, nbody::constants::velLineWidth, WHITE);
+                }
+                if (cfg.drawAcceleration) {
+                    const raylib::Vector2 tip = p.value + a.value * nbody::constants::accVectorScale;
+                    DrawLineEx(p.value, tip, nbody::constants::accLineWidth, ORANGE);
                 }
             });
+
+            EndMode2D();
         }
 
-        w.each([&](const Position& p, const Velocity& v, const Acceleration& a, const Mass& m, const Tint& tint) {
-            const float r = static_cast<float>(std::cbrt(std::max(1.0, static_cast<double>(m.value))));
-            DrawCircleV(p.value, r, tint.value);
-            if (cfg.drawVelocity) {
-                const raylib::Vector2 tip = p.value + v.value * 10.0f;
-                DrawLineEx(p.value, tip, 1.5f, WHITE);
+    private:
+        static void DrawWorldGrid(const raylib::Camera2D& cam, const float spacing) {
+            const raylib::Vector2 tl = GetScreenToWorld2D(::Vector2{0, 0}, cam);
+            const raylib::Vector2 br = GetScreenToWorld2D(
+                ::Vector2{static_cast<float>(GetScreenWidth()), static_cast<float>(GetScreenHeight())}, cam);
+
+            const float startX = std::floor(tl.x / spacing) * spacing;
+            const float endX = std::ceil(br.x / spacing) * spacing;
+            const float startY = std::floor(tl.y / spacing) * spacing;
+            const float endY = std::ceil(br.y / spacing) * spacing;
+
+            const int stepsX = static_cast<int>(
+                std::max(0.0f, std::floor((endX - startX) / spacing + nbody::constants::gridStepsEpsilon)));
+            for (int i = 0; i <= stepsX; ++i) {
+                const float x = startX + static_cast<float>(i) * spacing;
+                DrawLineV(::Vector2{x, startY}, ::Vector2{x, endY},
+                          (std::abs(x) < nbody::constants::gridAxisEpsilon) ? nbody::constants::axisColor
+                                                                            : nbody::constants::gridColor);
             }
-            if (cfg.drawAcceleration) {
-                const raylib::Vector2 tip = p.value + a.value * 500.0f;
-                DrawLineEx(p.value, tip, 1.0f, ORANGE);
+            const int stepsY = static_cast<int>(
+                std::max(0.0f, std::floor((endY - startY) / spacing + nbody::constants::gridStepsEpsilon)));
+            for (int j = 0; j <= stepsY; ++j) {
+                const float y = startY + static_cast<float>(j) * spacing;
+                DrawLineV(::Vector2{startX, y}, ::Vector2{endX, y},
+                          (std::abs(y) < nbody::constants::gridAxisEpsilon) ? nbody::constants::axisColor
+                                                                            : nbody::constants::gridColor);
             }
-        });
-
-        EndMode2D();
-    }
-
-private:
-    static void DrawWorldGrid(const raylib::Camera2D& cam, const float spacing) {
-        const raylib::Vector2 tl = GetScreenToWorld2D(::Vector2{0, 0}, cam);
-        const raylib::Vector2 br = GetScreenToWorld2D(
-            ::Vector2{static_cast<float>(GetScreenWidth()), static_cast<float>(GetScreenHeight())}, cam);
-
-        const float startX = std::floor(tl.x / spacing) * spacing;
-        const float endX = std::ceil(br.x / spacing) * spacing;
-        const float startY = std::floor(tl.y / spacing) * spacing;
-        const float endY = std::ceil(br.y / spacing) * spacing;
-
-        constexpr Color gridC = {40, 40, 40, 255};
-        constexpr Color axisC = {80, 80, 80, 255};
-
-        const int stepsX = static_cast<int>(std::max(0.0f, std::floor((endX - startX) / spacing + 1e-6f)));
-        for (int i = 0; i <= stepsX; ++i) {
-            const float x = startX + static_cast<float>(i) * spacing;
-            DrawLineV(::Vector2{x, startY}, ::Vector2{x, endY}, (std::abs(x) < 1e-4f) ? axisC : gridC);
         }
-        const int stepsY = static_cast<int>(std::max(0.0f, std::floor((endY - startY) / spacing + 1e-6f)));
-        for (int j = 0; j <= stepsY; ++j) {
-            const float y = startY + static_cast<float>(j) * spacing;
-            DrawLineV(::Vector2{startX, y}, ::Vector2{endX, y}, (std::abs(y) < 1e-4f) ? axisC : gridC);
-        }
-    }
-};
+    };
 
 }  // namespace nbody

--- a/src/systems/UI.hpp
+++ b/src/systems/UI.hpp
@@ -1,309 +1,339 @@
 #pragma once
 
+#include <algorithm>
 #include <cfloat>
 #include <cmath>
-#include <algorithm>
+#include <flecs.h>
+#include <imgui.h>
+#include <raylib-cpp.hpp>
+#include <raymath.h>
+#include <rlImGui.h>
 #include <string>
 #include <vector>
 
-#include <flecs.h>
-#include <imgui.h>
-#include <rlImGui.h>
-#include <raylib-cpp.hpp>
-#include <raymath.h>
-
 #include "../components/Components.hpp"
 #include "../core/Config.hpp"
-#include "Interaction.hpp"
+#include "../core/Constants.hpp"
 #include "Camera.hpp"
+#include "Interaction.hpp"
 
 namespace nbody {
 
-class UI {
-public:
-    static void Begin() { rlImGuiBegin(); }
-    static void End() { rlImGuiEnd(); }
+    class UI {
+    public:
+        static void Begin() { rlImGuiBegin(); }
+        static void End() { rlImGuiEnd(); }
 
-    static void Draw(const flecs::world& w, raylib::Camera2D& cam) {
-        auto* cfg = w.get_mut<Config>();
-        bool requestStep = false;
+        static void Draw(const flecs::world& w, raylib::Camera2D& cam) {
+            auto* cfg = w.get_mut<Config>();
+            bool requestStep = false;
 
-        ImGui::SetNextWindowPos(ImVec2(12, 12), ImGuiCond_FirstUseEver);
-        ImGui::SetNextWindowSize(ImVec2(360, 0), ImGuiCond_FirstUseEver);
-        ImGui::Begin("Time & Integrator");
-        ImGui::Checkbox("Paused", &cfg->paused);
-        ImGui::SameLine();
-        if (ImGui::Button("Step")) requestStep = true;
-        ImGui::Checkbox("Use Fixed dt", &cfg->useFixedDt);
-        ImGui::SliderFloat("Fixed dt", &cfg->fixedDt, 1e-4f, 0.05f, "%.6f");
-        ImGui::SliderFloat("Time Scale", &cfg->timeScale, 0.0f, 10.0f, "%.3f");
-        ImGui::RadioButton("Semi-Implicit Euler", &cfg->integrator, 0);
-        ImGui::SameLine();
-        ImGui::RadioButton("Velocity Verlet", &cfg->integrator, 1);
-        ImGui::Text("Last step: %.3f ms", cfg->lastStepMs);
-        ImGui::End();
+            ImGui::SetNextWindowPos(ImVec2(12, 12), ImGuiCond_FirstUseEver);
+            ImGui::SetNextWindowSize(ImVec2(360, 0), ImGuiCond_FirstUseEver);
+            ImGui::Begin("Time & Integrator");
+            ImGui::Checkbox("Paused", &cfg->paused);
+            ImGui::SameLine();
+            if (ImGui::Button("Step")) requestStep = true;
+            ImGui::Checkbox("Use Fixed dt", &cfg->useFixedDt);
+            ImGui::SliderFloat("Fixed dt", &cfg->fixedDt, nbody::constants::fixedDtMin, nbody::constants::fixedDtMax,
+                               "%.6f");
+            ImGui::SliderFloat("Time Scale", &cfg->timeScale, nbody::constants::timeScaleMin,
+                               nbody::constants::timeScaleMax, "%.3f");
+            ImGui::RadioButton("Semi-Implicit Euler", &cfg->integrator, 0);
+            ImGui::SameLine();
+            ImGui::RadioButton("Velocity Verlet", &cfg->integrator, 1);
+            ImGui::Text("Last step: %.3f ms", cfg->lastStepMs);
+            ImGui::End();
 
-        ImGui::SetNextWindowPos(ImVec2(12, 140), ImGuiCond_FirstUseEver);
-        ImGui::SetNextWindowSize(ImVec2(360, 0), ImGuiCond_FirstUseEver);
-        ImGui::Begin("Physics");
-        auto Gf = static_cast<float>(cfg->G);
-        ImGui::SliderFloat("G", &Gf, 0.0f, 0.02f, "%.6f");
-        cfg->G = Gf;
-        ImGui::SliderFloat("Softening (epsilon)", &cfg->softening, 0.0f, 20.0f, "%.3f");
-        ImGui::SliderFloat("Velocity Cap", &cfg->maxSpeed, 0.0f, 200.0f, "%.1f");
-        if (ImGui::Button("Zero Net Momentum")) zero_net_momentum(w);
-        ImGui::SameLine();
-        if (ImGui::Button("Reset Scenario")) {
-            reset_scenario(w);
-            zero_net_momentum(w);
-            Interaction::Select(w, flecs::entity::null());
-            cfg->paused = false;
-        }
-        ImGui::End();
-
-        ImGui::SetNextWindowPos(ImVec2(12, 280), ImGuiCond_FirstUseEver);
-        ImGui::SetNextWindowSize(ImVec2(360, 0), ImGuiCond_FirstUseEver);
-        ImGui::Begin("Visuals");
-        ImGui::Checkbox("Trails", &cfg->drawTrails);
-        ImGui::SameLine();
-        ImGui::Checkbox("Velocity Vectors", &cfg->drawVelocity);
-        ImGui::SameLine();
-        ImGui::Checkbox("Acceleration Vectors", &cfg->drawAcceleration);
-        ImGui::SliderInt("Trail Length", &cfg->trailMax, 0, 2000);
-        ImGui::End();
-
-        static float spawnMass = 12.0f;
-        static raylib::Vector2 spawnVel{0, 0};
-        static bool spawnPinned = false;
-        static float dragVelScale = 0.01f;
-        ImGui::SetNextWindowPos(ImVec2(12, 420), ImGuiCond_FirstUseEver);
-        ImGui::SetNextWindowSize(ImVec2(380, 0), ImGuiCond_FirstUseEver);
-        ImGui::Begin("Add / Edit");
-        ImGui::SliderFloat("Spawn Mass", &spawnMass, 1.0f, 5000.0f, "%.1f");
-        ImGui::SliderFloat2("Spawn Velocity", &spawnVel.x, -5.0f, 5.0f, "%.3f");
-        ImGui::Checkbox("Spawn Pinned", &spawnPinned);
-        if (ImGui::Button("Add Body At Mouse")) {
-            const raylib::Vector2 mouseWorld = GetScreenToWorld2D(GetMousePosition(), cam);
-            w.entity()
-                .set<Position>({mouseWorld})
-                .set<Velocity>({spawnVel})
-                .set<Acceleration>({raylib::Vector2{0, 0}})
-                .set<PrevAcceleration>({raylib::Vector2{0, 0}})
-                .set<Mass>({std::max(1.0f, spawnMass)})
-                .set<Pinned>({spawnPinned})
-                .set<Tint>({RandomNiceColor()})
-                .set<Trail>({{}})
-                .add<Selectable>()
-                .set<Draggable>({true, dragVelScale});
-        }
-        ImGui::SliderFloat("Right-Drag Vel Scale", &dragVelScale, 0.001f, 0.2f, "%.3f");
-
-        if (flecs::entity selected = Interaction::GetSelected(w); selected.is_alive()) {
-            const auto mass = selected.get_mut<Mass>();
-            const auto vel = selected.get_mut<Velocity>();
-            const auto pin = selected.get_mut<Pinned>();
-            if (ImGui::CollapsingHeader("Selected Body", ImGuiTreeNodeFlags_DefaultOpen)) {
-                ImGui::Text("Entity: %lld", static_cast<long long>(selected.id()));
-                ImGui::Checkbox("Pinned", &pin->value);
-                ImGui::SliderFloat("Mass", &mass->value, 1.0f, 10000.0f, "%.1f");
-                ImGui::SliderFloat2("Velocity", &vel->value.x, -200.0f, 200.0f, "%.3f");
-                if (ImGui::Button("Zero Velocity")) vel->value = raylib::Vector2{0.0f, 0.0f};
-                ImGui::SameLine();
-                if (ImGui::Button("Remove Body")) {
-                    selected.destruct();
-                    Interaction::Select(w, flecs::entity::null());
-                }
-                ImGui::SameLine();
-                if (ImGui::Button("Focus Camera")) {
-                    if (const auto p = selected.get<Position>()) cam.target = p->value;
-                }
+            ImGui::SetNextWindowPos(ImVec2(12, 140), ImGuiCond_FirstUseEver);
+            ImGui::SetNextWindowSize(ImVec2(360, 0), ImGuiCond_FirstUseEver);
+            ImGui::Begin("Physics");
+            auto Gf = static_cast<float>(cfg->G);
+            ImGui::SliderFloat("G", &Gf, nbody::constants::gMin, nbody::constants::gMax, "%.6f");
+            cfg->G = Gf;
+            ImGui::SliderFloat("Softening (epsilon)", &cfg->softening, nbody::constants::softeningMin,
+                               nbody::constants::softeningMax, "%.3f");
+            ImGui::SliderFloat("Velocity Cap", &cfg->maxSpeed, nbody::constants::velocityCapMin,
+                               nbody::constants::velocityCapMax, "%.1f");
+            if (ImGui::Button("Zero Net Momentum")) zero_net_momentum(w);
+            ImGui::SameLine();
+            if (ImGui::Button("Reset Scenario")) {
+                reset_scenario(w);
+                zero_net_momentum(w);
+                Interaction::Select(w, flecs::entity::null());
+                cfg->paused = false;
             }
-        }
-        ImGui::End();
+            ImGui::End();
 
-        ImGui::SetNextWindowPos(ImVec2(400, 12), ImGuiCond_FirstUseEver);
-        ImGui::SetNextWindowSize(ImVec2(380, 360), ImGuiCond_FirstUseEver);
-        ImGui::Begin("Bodies");
-        flecs::entity pendingSelection = flecs::entity::null();
+            ImGui::SetNextWindowPos(ImVec2(12, 280), ImGuiCond_FirstUseEver);
+            ImGui::SetNextWindowSize(ImVec2(360, 0), ImGuiCond_FirstUseEver);
+            ImGui::Begin("Visuals");
+            ImGui::Checkbox("Trails", &cfg->drawTrails);
+            ImGui::SameLine();
+            ImGui::Checkbox("Velocity Vectors", &cfg->drawVelocity);
+            ImGui::SameLine();
+            ImGui::Checkbox("Acceleration Vectors", &cfg->drawAcceleration);
+            ImGui::SliderInt("Trail Length", &cfg->trailMax, 0, nbody::constants::trailLengthMax);
+            ImGui::End();
 
-        // Create a scrolling list with a fixed-height footer for action buttons.
-        const float footer_h = ImGui::GetFrameHeightWithSpacing();
-        if (ImGui::BeginChild("##BodyList", ImVec2(0, -footer_h), true)) {
-            // Build stable-ordered list to avoid reordering issues
-            std::vector<flecs::entity> entities;
-            w.each([&](const flecs::entity e, const Position&, const Mass&, const Tint&, const Selectable&) {
-                entities.push_back(e);
-            });
-            std::sort(entities.begin(), entities.end(), [](const flecs::entity& a, const flecs::entity& b) {
-                return a.id() < b.id();
-            });
-
-            for (auto e : entities) {
-                const auto* p = e.get<Position>();
-                const auto* m = e.get<Mass>();
-                const auto* t = e.get<Tint>();
-                if (!p || !m || !t) continue;
-                const bool isSel = (Interaction::GetSelected(w).is_alive() && Interaction::GetSelected(w).id() == e.id());
-                ImGui::PushID(static_cast<int>(e.id()));
-                ImGui::ColorButton("##c", ImVec4(t->value.r / 255.0f, t->value.g / 255.0f, t->value.b / 255.0f, 1.0f), 0,
-                                   ImVec2(16, 16));
-                ImGui::SameLine();
-                if (ImGui::Selectable(("Entity " + std::to_string(e.id())).c_str(), isSel)) pendingSelection = e;
-                ImGui::SameLine();
-                ImGui::Text("pos(%.1f, %.1f) m=%.1f", p->value.x, p->value.y, m->value);
-                ImGui::PopID();
+            static float spawnMass = nbody::constants::seedSmallMass;
+            static raylib::Vector2 spawnVel{0, 0};
+            static bool spawnPinned = false;
+            static float dragVelScale = nbody::constants::dragVelScale;
+            ImGui::SetNextWindowPos(ImVec2(12, 420), ImGuiCond_FirstUseEver);
+            ImGui::SetNextWindowSize(ImVec2(380, 0), ImGuiCond_FirstUseEver);
+            ImGui::Begin("Add / Edit");
+            ImGui::SliderFloat("Spawn Mass", &spawnMass, nbody::constants::spawnMassMin, nbody::constants::spawnMassMax,
+                               "%.1f");
+            ImGui::SliderFloat2("Spawn Velocity", &spawnVel.x, nbody::constants::spawnVelMin,
+                                nbody::constants::spawnVelMax, "%.3f");
+            ImGui::Checkbox("Spawn Pinned", &spawnPinned);
+            if (ImGui::Button("Add Body At Mouse")) {
+                const raylib::Vector2 mouseWorld = GetScreenToWorld2D(GetMousePosition(), cam);
+                w.entity()
+                    .set<Position>({mouseWorld})
+                    .set<Velocity>({spawnVel})
+                    .set<Acceleration>({raylib::Vector2{0, 0}})
+                    .set<PrevAcceleration>({raylib::Vector2{0, 0}})
+                    .set<Mass>({std::max(nbody::constants::spawnMassMin, spawnMass)})
+                    .set<Pinned>({spawnPinned})
+                    .set<Tint>({RandomNiceColor()})
+                    .set<Trail>({{}})
+                    .add<Selectable>()
+                    .set<Draggable>({true, dragVelScale});
             }
-        }
-        ImGui::EndChild();
+            ImGui::SliderFloat("Right-Drag Vel Scale", &dragVelScale, nbody::constants::dragVelScaleMin,
+                               nbody::constants::dragVelScaleMax, "%.3f");
 
-        // Footer actions (always visible at bottom)
-        if (ImGui::Button("Duplicate Selected")) {
             if (flecs::entity selected = Interaction::GetSelected(w); selected.is_alive()) {
-                const auto e = selected;
-                if (const auto p0 = e.get<Position>();
-                    p0 && e.get<Velocity>() && e.get<Mass>() && e.get<Tint>() && e.get<Pinned>()) {
-                    auto p = *p0;
-                    auto v = *e.get<Velocity>();
-                    auto m = *e.get<Mass>();
-                    auto t = *e.get<Tint>();
-                    auto pin = *e.get<Pinned>();
-                    p.value += raylib::Vector2{20.0f, 0.0f};
-                    w.entity()
-                        .set(p)
-                        .set(v)
-                        .set(Acceleration{raylib::Vector2{0, 0}})
-                        .set(PrevAcceleration{raylib::Vector2{0, 0}})
-                        .set(m)
-                        .set(pin)
-                        .set(t)
-                        .set(Trail{{}})
-                        .add<Selectable>()
-                        .set<Draggable>({true, dragVelScale});
+                const auto mass = selected.get_mut<Mass>();
+                const auto vel = selected.get_mut<Velocity>();
+                const auto pin = selected.get_mut<Pinned>();
+                if (ImGui::CollapsingHeader("Selected Body", ImGuiTreeNodeFlags_DefaultOpen)) {
+                    ImGui::Text("Entity: %lld", static_cast<long long>(selected.id()));
+                    ImGui::Checkbox("Pinned", &pin->value);
+                    ImGui::SliderFloat("Mass", &mass->value, nbody::constants::selectedMassMin,
+                                       nbody::constants::selectedMassMax, "%.1f");
+                    ImGui::SliderFloat2("Velocity", &vel->value.x, nbody::constants::selectedVelMin,
+                                        nbody::constants::selectedVelMax, "%.3f");
+                    if (ImGui::Button("Zero Velocity")) vel->value = raylib::Vector2{0.0f, 0.0f};
+                    ImGui::SameLine();
+                    if (ImGui::Button("Remove Body")) {
+                        selected.destruct();
+                        Interaction::Select(w, flecs::entity::null());
+                    }
+                    ImGui::SameLine();
+                    if (ImGui::Button("Focus Camera")) {
+                        if (const auto p = selected.get<Position>()) cam.target = p->value;
+                    }
                 }
             }
-        }
-        ImGui::SameLine();
-        if (ImGui::Button("Recenter to COM")) {
-            nbody::Camera::CenterOnCenterOfMass(w);
-        }
-        ImGui::End();
+            ImGui::End();
 
-        if (pendingSelection.is_alive() || (!Interaction::GetSelected(w).is_alive() && pendingSelection == flecs::entity::null())) {
-            Interaction::Select(w, pendingSelection);
-        }
+            ImGui::SetNextWindowPos(ImVec2(400, 12), ImGuiCond_FirstUseEver);
+            ImGui::SetNextWindowSize(ImVec2(380, 360), ImGuiCond_FirstUseEver);
+            ImGui::Begin("Bodies");
+            flecs::entity pendingSelection = flecs::entity::null();
 
-        Diagnostics d{};
-        const bool okDiag = compute_diagnostics(w, cfg->G,
-            static_cast<double>(cfg->softening) * static_cast<double>(cfg->softening), d);
-        ImGui::SetNextWindowPos(ImVec2(400, 390), ImGuiCond_FirstUseEver);
-        ImGui::SetNextWindowSize(ImVec2(380, 0), ImGuiCond_FirstUseEver);
-        ImGui::Begin("Diagnostics");
-        ImGui::Text("Kinetic: %.6g", d.kinetic);
-        ImGui::Text("Potential: %.6g", d.potential);
-        ImGui::Text("Total: %.6g", d.energy);
-        ImGui::Text("Momentum: (%.6g, %.6g)", d.momentum.x, d.momentum.y);
-        ImGui::Text("COM: (%.3f, %.3f)  Mass: %.3f", d.com.x, (d.totalMass > 0.0) ? d.com.y : 0.0f, d.totalMass);
-        if (!okDiag) ImGui::TextColored(ImVec4(1, 0.3f, 0.3f, 1), "Non-finite detected; auto-paused.");
-        ImGui::End();
+            // Create a scrolling list with a fixed-height footer for action buttons.
+            const float footer_h = ImGui::GetFrameHeightWithSpacing();
+            if (ImGui::BeginChild("##BodyList", ImVec2(0, -footer_h), true)) {
+                // Build stable-ordered list to avoid reordering issues
+                std::vector<flecs::entity> entities;
+                w.each([&](const flecs::entity e, const Position&, const Mass&, const Tint&, const Selectable&) {
+                    entities.push_back(e);
+                });
+                std::sort(entities.begin(), entities.end(),
+                          [](const flecs::entity& a, const flecs::entity& b) { return a.id() < b.id(); });
 
-        if (requestStep) {
-            const bool old = cfg->paused;
-            cfg->paused = false;
-            w.progress(cfg->fixedDt);
-            cfg->paused = old;
-        }
-    }
+                for (auto e : entities) {
+                    const auto* p = e.get<Position>();
+                    const auto* m = e.get<Mass>();
+                    const auto* t = e.get<Tint>();
+                    if (!p || !m || !t) continue;
+                    const bool isSel =
+                        (Interaction::GetSelected(w).is_alive() && Interaction::GetSelected(w).id() == e.id());
+                    ImGui::PushID(static_cast<int>(e.id()));
+                    ImGui::ColorButton("##c",
+                                       ImVec4(t->value.r / static_cast<float>(nbody::constants::randomColorMax),
+                                              t->value.g / static_cast<float>(nbody::constants::randomColorMax),
+                                              t->value.b / static_cast<float>(nbody::constants::randomColorMax), 1.0f),
+                                       0, ImVec2(16, 16));
+                    ImGui::SameLine();
+                    if (ImGui::Selectable(("Entity " + std::to_string(e.id())).c_str(), isSel)) pendingSelection = e;
+                    ImGui::SameLine();
+                    ImGui::Text("pos(%.1f, %.1f) m=%.1f", p->value.x, p->value.y, m->value);
+                    ImGui::PopID();
+                }
+            }
+            ImGui::EndChild();
 
-private:
-    struct Diagnostics {
-        double kinetic = 0.0;
-        double potential = 0.0;
-        double energy = 0.0;
-        raylib::Vector2 momentum{0, 0};
-        raylib::Vector2 com{0, 0};
-        double totalMass = 0.0;
-    };
+            // Footer actions (always visible at bottom)
+            if (ImGui::Button("Duplicate Selected")) {
+                if (flecs::entity selected = Interaction::GetSelected(w); selected.is_alive()) {
+                    const auto e = selected;
+                    if (const auto p0 = e.get<Position>();
+                        p0 && e.get<Velocity>() && e.get<Mass>() && e.get<Tint>() && e.get<Pinned>()) {
+                        auto p = *p0;
+                        auto v = *e.get<Velocity>();
+                        auto m = *e.get<Mass>();
+                        auto t = *e.get<Tint>();
+                        auto pin = *e.get<Pinned>();
+                        p.value += raylib::Vector2{nbody::constants::duplicateOffsetX, 0.0f};
+                        w.entity()
+                            .set(p)
+                            .set(v)
+                            .set(Acceleration{raylib::Vector2{0, 0}})
+                            .set(PrevAcceleration{raylib::Vector2{0, 0}})
+                            .set(m)
+                            .set(pin)
+                            .set(t)
+                            .set(Trail{{}})
+                            .add<Selectable>()
+                            .set<Draggable>({true, dragVelScale});
+                    }
+                }
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Recenter to COM")) {
+                nbody::Camera::CenterOnCenterOfMass(w);
+            }
+            ImGui::End();
 
-    static raylib::Color RandomNiceColor() {
-        return {static_cast<unsigned char>(GetRandomValue(64, 255)), static_cast<unsigned char>(GetRandomValue(64, 255)),
-                static_cast<unsigned char>(GetRandomValue(64, 255)), 255};
-    }
+            if (pendingSelection.is_alive() ||
+                (!Interaction::GetSelected(w).is_alive() && pendingSelection == flecs::entity::null())) {
+                Interaction::Select(w, pendingSelection);
+            }
 
-    static void zero_net_momentum(const flecs::world& w) {
-        double Px = 0.0, Py = 0.0, M = 0.0;
-        w.each([&](const Mass& m, const Velocity& v) {
-            Px += static_cast<double>(m.value) * static_cast<double>(v.value.x);
-            Py += static_cast<double>(m.value) * static_cast<double>(v.value.y);
-            M += static_cast<double>(m.value);
-        });
-        if (M <= 0.0) return;
-        const raylib::Vector2 v0 = {static_cast<float>(Px / M), static_cast<float>(Py / M)};
-        w.each([&](const Pinned& pin, Velocity& v) { if (!pin.value) v.value -= v0; });
-    }
+            Diagnostics d{};
+            const bool okDiag = compute_diagnostics(
+                w, cfg->G, static_cast<double>(cfg->softening) * static_cast<double>(cfg->softening), d);
+            ImGui::SetNextWindowPos(ImVec2(400, 390), ImGuiCond_FirstUseEver);
+            ImGui::SetNextWindowSize(ImVec2(380, 0), ImGuiCond_FirstUseEver);
+            ImGui::Begin("Diagnostics");
+            ImGui::Text("Kinetic: %.6g", d.kinetic);
+            ImGui::Text("Potential: %.6g", d.potential);
+            ImGui::Text("Total: %.6g", d.energy);
+            ImGui::Text("Momentum: (%.6g, %.6g)", d.momentum.x, d.momentum.y);
+            ImGui::Text("COM: (%.3f, %.3f)  Mass: %.3f", d.com.x, (d.totalMass > 0.0) ? d.com.y : 0.0f, d.totalMass);
+            if (!okDiag) ImGui::TextColored(ImVec4(1, 0.3f, 0.3f, 1), "Non-finite detected; auto-paused.");
+            ImGui::End();
 
-    static void reset_scenario(const flecs::world& w) {
-        std::vector<flecs::entity> to_del;
-        w.each([&](const flecs::entity e, Position&) { to_del.push_back(e); });
-        for (auto& e : to_del) e.destruct();
-        auto mk = [&](const raylib::Vector2 pos, const raylib::Vector2 vel, const float mass, const raylib::Color col,
-                      const bool pinned) {
-            w.entity()
-                .set<Position>({pos})
-                .set<Velocity>({vel})
-                .set<Acceleration>({raylib::Vector2{0, 0}})
-                .set<PrevAcceleration>({raylib::Vector2{0, 0}})
-                .set<Mass>({mass})
-                .set<Pinned>({pinned})
-                .set<Tint>({col})
-                .set<Trail>({{}})
-                .add<Selectable>()
-                .set<Draggable>({true, 0.01f});
-        };
-        mk({640, 360}, {0.0f, 0.0f}, 4000.0f, RED, false);
-        mk({840, 360}, {0.0f, 1.20f}, 12.0f, BLUE, false);
-        mk({440, 360}, {0.0f, -1.20f}, 12.0f, GREEN, false);
-    }
-
-    static bool compute_diagnostics(const flecs::world& w, const double G, const double eps2, Diagnostics& out) {
-        std::vector<std::tuple<raylib::Vector2, raylib::Vector2, float>> data;
-        data.reserve(1024);
-        w.each([&](const Position& p, const Velocity& v, const Mass& m) { data.emplace_back(p.value, v.value, m.value); });
-        const size_t n = data.size();
-        out = Diagnostics{};
-        if (n == 0) return true;
-
-        double KE = 0.0, M = 0.0, Px = 0.0, Py = 0.0, Cx = 0.0, Cy = 0.0;
-        for (size_t i = 0; i < n; ++i) {
-            auto [p, v, m] = data[i];
-            KE += 0.5 * static_cast<double>(m) *
-                  (static_cast<double>(v.x) * static_cast<double>(v.x) + static_cast<double>(v.y) * static_cast<double>(v.y));
-            Px += static_cast<double>(m) * static_cast<double>(v.x);
-            Py += static_cast<double>(m) * static_cast<double>(v.y);
-            Cx += static_cast<double>(m) * static_cast<double>(p.x);
-            Cy += static_cast<double>(m) * static_cast<double>(p.y);
-            M += static_cast<double>(m);
-        }
-        double PE = 0.0;
-        for (size_t i = 0; i < n; ++i) {
-            for (size_t j = i + 1; j < n; ++j) {
-                const double dx = static_cast<double>(std::get<0>(data[j]).x) - static_cast<double>(std::get<0>(data[i]).x);
-                const double dy = static_cast<double>(std::get<0>(data[j]).y) - static_cast<double>(std::get<0>(data[i]).y);
-                const double r2 = dx * dx + dy * dy + eps2;
-                const double r = std::sqrt(r2);
-                PE += -G * static_cast<double>(std::get<2>(data[i])) * static_cast<double>(std::get<2>(data[j])) / r;
+            if (requestStep) {
+                const bool old = cfg->paused;
+                cfg->paused = false;
+                w.progress(cfg->fixedDt);
+                cfg->paused = old;
             }
         }
 
-        out.kinetic = KE;
-        out.potential = PE;
-        out.energy = KE + PE;
-        out.momentum = raylib::Vector2{static_cast<float>(Px), static_cast<float>(Py)};
-        out.totalMass = M;
-        out.com = (M > 0.0) ? raylib::Vector2{static_cast<float>(Cx / M), static_cast<float>(Cy / M)} : raylib::Vector2{0, 0};
-        return true;
-    }
+    private:
+        struct Diagnostics {
+            double kinetic = 0.0;
+            double potential = 0.0;
+            double energy = 0.0;
+            raylib::Vector2 momentum{0, 0};
+            raylib::Vector2 com{0, 0};
+            double totalMass = 0.0;
+        };
 
-    // No extra bridge helpers needed when including Interaction.hpp
-};
+        static raylib::Color RandomNiceColor() {
+            return {static_cast<unsigned char>(
+                        GetRandomValue(nbody::constants::randomColorMin, nbody::constants::randomColorMax)),
+                    static_cast<unsigned char>(
+                        GetRandomValue(nbody::constants::randomColorMin, nbody::constants::randomColorMax)),
+                    static_cast<unsigned char>(
+                        GetRandomValue(nbody::constants::randomColorMin, nbody::constants::randomColorMax)),
+                    255};
+        }
+
+        static void zero_net_momentum(const flecs::world& w) {
+            double Px = 0.0, Py = 0.0, M = 0.0;
+            w.each([&](const Mass& m, const Velocity& v) {
+                Px += static_cast<double>(m.value) * static_cast<double>(v.value.x);
+                Py += static_cast<double>(m.value) * static_cast<double>(v.value.y);
+                M += static_cast<double>(m.value);
+            });
+            if (M <= 0.0) return;
+            const raylib::Vector2 v0 = {static_cast<float>(Px / M), static_cast<float>(Py / M)};
+            w.each([&](const Pinned& pin, Velocity& v) {
+                if (!pin.value) v.value -= v0;
+            });
+        }
+
+        static void reset_scenario(const flecs::world& w) {
+            std::vector<flecs::entity> to_del;
+            w.each([&](const flecs::entity e, Position&) { to_del.push_back(e); });
+            for (auto& e : to_del) e.destruct();
+            auto mk = [&](const raylib::Vector2 pos, const raylib::Vector2 vel, const float mass,
+                          const raylib::Color col, const bool pinned) {
+                w.entity()
+                    .set<Position>({pos})
+                    .set<Velocity>({vel})
+                    .set<Acceleration>({raylib::Vector2{0, 0}})
+                    .set<PrevAcceleration>({raylib::Vector2{0, 0}})
+                    .set<Mass>({mass})
+                    .set<Pinned>({pinned})
+                    .set<Tint>({col})
+                    .set<Trail>({{}})
+                    .add<Selectable>()
+                    .set<Draggable>({true, nbody::constants::dragVelScale});
+            };
+            mk({nbody::constants::seedCenterX, nbody::constants::seedCenterY}, {0.0f, 0.0f},
+               nbody::constants::seedCentralMass, RED, false);
+            mk({nbody::constants::seedCenterX + nbody::constants::seedOffsetX, nbody::constants::seedCenterY},
+               {0.0f, nbody::constants::seedSpeed}, nbody::constants::seedSmallMass, BLUE, false);
+            mk({nbody::constants::seedCenterX - nbody::constants::seedOffsetX, nbody::constants::seedCenterY},
+               {0.0f, -nbody::constants::seedSpeed}, nbody::constants::seedSmallMass, GREEN, false);
+        }
+
+        static bool compute_diagnostics(const flecs::world& w, const double G, const double eps2, Diagnostics& out) {
+            std::vector<std::tuple<raylib::Vector2, raylib::Vector2, float>> data;
+            data.reserve(1024);
+            w.each([&](const Position& p, const Velocity& v, const Mass& m) {
+                data.emplace_back(p.value, v.value, m.value);
+            });
+            const size_t n = data.size();
+            out = Diagnostics{};
+            if (n == 0) return true;
+
+            double KE = 0.0, M = 0.0, Px = 0.0, Py = 0.0, Cx = 0.0, Cy = 0.0;
+            for (size_t i = 0; i < n; ++i) {
+                auto [p, v, m] = data[i];
+                KE += 0.5 * static_cast<double>(m) *
+                    (static_cast<double>(v.x) * static_cast<double>(v.x) +
+                     static_cast<double>(v.y) * static_cast<double>(v.y));
+                Px += static_cast<double>(m) * static_cast<double>(v.x);
+                Py += static_cast<double>(m) * static_cast<double>(v.y);
+                Cx += static_cast<double>(m) * static_cast<double>(p.x);
+                Cy += static_cast<double>(m) * static_cast<double>(p.y);
+                M += static_cast<double>(m);
+            }
+            double PE = 0.0;
+            for (size_t i = 0; i < n; ++i) {
+                for (size_t j = i + 1; j < n; ++j) {
+                    const double dx =
+                        static_cast<double>(std::get<0>(data[j]).x) - static_cast<double>(std::get<0>(data[i]).x);
+                    const double dy =
+                        static_cast<double>(std::get<0>(data[j]).y) - static_cast<double>(std::get<0>(data[i]).y);
+                    const double r2 = dx * dx + dy * dy + eps2;
+                    const double r = std::sqrt(r2);
+                    PE +=
+                        -G * static_cast<double>(std::get<2>(data[i])) * static_cast<double>(std::get<2>(data[j])) / r;
+                }
+            }
+
+            out.kinetic = KE;
+            out.potential = PE;
+            out.energy = KE + PE;
+            out.momentum = raylib::Vector2{static_cast<float>(Px), static_cast<float>(Py)};
+            out.totalMass = M;
+            out.com = (M > 0.0) ? raylib::Vector2{static_cast<float>(Cx / M), static_cast<float>(Cy / M)}
+                                : raylib::Vector2{0, 0};
+            return true;
+        }
+
+        // No extra bridge helpers needed when including Interaction.hpp
+    };
 
 }  // namespace nbody


### PR DESCRIPTION
## Summary
- expand `nbody::constants` with ring, grid, vector and UI range values
- replace residual magic numbers in Interaction, Renderer, Camera and UI

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` *(fails: Vendored raylib not found and no system raylib available)*
- `apt-get update`
- `apt-get install -y libraylib-dev` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a21acb1c28832999d5235786817ff8