### PR TITLE
docs: sync guidance with current ECS implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,15 +22,17 @@ Single source of truth for OpenAI agents and Claude Code. Link or symlink `CLAUD
 **Notes**
 
 - Works with Ninja and default CMake generators. Prefer the canonical out-of-source flow when possible.
-- raylib must be installed locally; ImGui and rlImGui are fetched during configure.
+- Ensure submodules are present: `git submodule update --init --recursive`.
+- raylib development files must be available locally. Other deps (raylib-cpp, ImGui, rlImGui, flecs) are vendored.
 
 ---
 
 ## Project Structure
 
 - Source entry: `src/main.cpp` (C++23).
-- Build system: `CMakeLists.txt` uses FetchContent for ImGui/rlImGui.
-- Add new modules under `src/` (e.g., `src/physics.*`, `src/ui.*`).
+- ECS components in `src/components/`, shared config/constants in `src/core/`.
+- Systems (physics, camera, interaction, rendering, UI) live under `src/systems/`.
+- Dependencies are managed via vendored submodules in `external/`.
 
 ---
 
@@ -38,20 +40,22 @@ Single source of truth for OpenAI agents and Claude Code. Link or symlink `CLAUD
 
 **Libraries and language**
 
-- raylib for windowing and rendering.
+- raylib for windowing and rendering (via raylib-cpp wrapper).
+- flecs for the ECS world.
 - ImGui + rlImGui for UI.
 - C++23 with STL containers.
 
 **Core simulation components**
 
-- `Body` struct: position, velocity, mass, color, pinned state.
-- Physics integrators: Semi-Implicit Euler and Velocity Verlet.
-- UI: time control, physics parameters, visuals, body editing.
-- Camera: pan, zoom, body selection, velocity dragging.
-- Diagnostics: energy checks with auto-pause on non-finite values.
+- ECS components: `Position`, `Velocity`, `Acceleration`, `PrevAcceleration`, `Mass`,
+  `Pinned`, `Tint`, `Trail`, `Selectable`, `Selected`, `Draggable`.
+- Systems: physics (gravity, integration, trails), camera, interaction, rendering, and UI.
+- Integrators: Semi-Implicit Euler and Velocity Verlet.
+- Diagnostics: energy/momentum checks with auto-pause on non-finite values.
 
 **Key patterns**
 
+- flecs systems drive the update loop.
 - Physics loop: acceleration computation → integration step → trail update.
 - Immediate-mode UI state in separate control windows.
 - Input routing between UI and world space.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # N-Body Gravity Simulation
 
-Real-time, interactive N-body gravity simulation built with raylib and ImGui.
+Real-time, interactive N-body gravity simulation built with raylib, flecs, and ImGui.
 
 ## Features
 
@@ -20,32 +20,20 @@ Real-time, interactive N-body gravity simulation built with raylib and ImGui.
 
 ## Building
 
-Requires raylib installed on your system.
+Requires the raylib development package installed on your system. Other dependencies are
+vendored as Git submodules.
 
 ```bash
-cmake --build cmake-build-debug
-./cmake-build-debug/raylib_nbody
+git submodule update --init --recursive
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+cmake --build build -j
+./build/raylib_nbody
 ```
 
 ## Dependencies
 
 - raylib (graphics and windowing)
-- ImGui (UI framework, fetched automatically)
-- rlImGui (raylib-ImGui integration, fetched automatically)
-
-## TODO
-
-High Priority (Correctness/Maintainability):
-1. Remove dead code (Selection, CameraState, unused components)
-2. Consolidate duplicate constants into shared header
-3. Add proper null checks and error handling
-
-Medium Priority (Code Quality):
-1. Extract constants for magic numbers
-2. Break down large methods (draw_ui, ProcessMouseInput)
-3. Move static functions into appropriate classes/namespaces
-
-Low Priority (Performance):
-1. Optimize data access patterns in physics
-2. Consider object pooling for frequent allocations
-3. Add spatial partitioning for large N-body simulations
+- raylib-cpp (C++ wrapper for raylib)
+- ImGui (UI framework)
+- rlImGui (raylib-ImGui bridge)
+- flecs (entity-component system)


### PR DESCRIPTION
## Summary
- clarify vendored dependencies and submodule init in `AGENTS.md`
- document ECS structure and flecs usage
- refresh README build steps and dependency list

## Testing
- `cmake --build build -j`
- `./build/raylib_nbody` *(fails: glfwGetWindowContentScale assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a04b6d04832985f2c9aa304055d0