### PR TITLE
refactor: extract world renderer utility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ add_executable(raylib_nbody
     src/core/Config.hpp
     src/components/Components.hpp
     src/systems/Physics.hpp
-    src/systems/Render.hpp
+    src/systems/WorldRenderer.hpp
     src/systems/UI.hpp
     src/systems/Camera.hpp
     src/systems/Interaction.hpp

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,8 +15,8 @@
 #include "systems/Camera.hpp"
 #include "systems/Interaction.hpp"
 #include "systems/Physics.hpp"
-#include "systems/Render.hpp"
 #include "systems/UI.hpp"
+#include "systems/WorldRenderer.hpp"
 
 namespace scenario {
     void CreateInitialBodies(const flecs::world& world) {
@@ -145,7 +145,7 @@ private:
         // Get configuration for rendering
         if (const auto* cfg = world_.get<Config>()) {
             // Render the physics scene
-            nbody::Renderer::RenderScene(world_, *cfg, *camera);
+            nbody::systems::WorldRenderer::RenderScene(world_, *cfg, *camera);
         }
 
         // Render interaction overlays (selection rings, drag visuals)

--- a/src/systems/WorldRenderer.hpp
+++ b/src/systems/WorldRenderer.hpp
@@ -10,9 +10,9 @@
 #include "../core/Config.hpp"
 #include "../core/Constants.hpp"
 
-namespace nbody {
+namespace nbody::systems {
 
-    class Renderer {
+    class WorldRenderer {
     public:
         static void RenderScene(const flecs::world& w, const Config& cfg, raylib::Camera2D& cam) {
             cam.BeginMode();
@@ -78,4 +78,4 @@ namespace nbody {
         }
     };
 
-}  // namespace nbody
+}  // namespace nbody::systems


### PR DESCRIPTION
## Summary
- move world rendering helpers into nbody::systems::WorldRenderer
- update includes and build files accordingly
- drop obsolete Render header

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build -j`
- `./build/raylib_nbody` *(fails: glfwGetWindowContentScale assertion `window != NULL`)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a57d1de08329abc3ad68d07f4255