### PR TITLE
Handle missing config in UI and log startup exceptions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -183,7 +183,7 @@ auto main() -> int {
         app.Run();
         return 0;
     } catch (const std::exception& e) {
-        // Log error if needed
+        TraceLog(LOG_ERROR, "Exception: %s", e.what());
         return 1;
     }
 }

--- a/src/systems/UI.hpp
+++ b/src/systems/UI.hpp
@@ -26,6 +26,7 @@ namespace nbody {
 
         static void Draw(const flecs::world& w, raylib::Camera2D& cam) {
             auto* cfg = w.get_mut<Config>();
+            if (!cfg) return;
             bool requestStep = false;
 
             ImGui::SetNextWindowPos(ImVec2(12, 12), ImGuiCond_FirstUseEver);


### PR DESCRIPTION
## Summary
- Avoid crashing `UI::Draw` when the configuration component is missing
- Log exceptions via `TraceLog` at startup

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build -j`
- `./build/raylib_nbody` *(fails: glfwGetWindowContentScale assertion `window != NULL`)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a5c7ced4832999fc157747b1fbbe