### PR TITLE
core: pool trail memory

### DIFF
--- a/src/components/Components.hpp
+++ b/src/components/Components.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <raylib-cpp.hpp>
+#include <utility>
 #include <vector>
 
 #include "../core/Constants.hpp"
+#include "../core/TrailPool.hpp"
 
 // Basic physics/render components
 struct Position {
@@ -31,6 +33,9 @@ struct Tint {
 // Trail history per entity
 struct Trail {
     std::vector<raylib::Vector2> points;
+    ~Trail() {
+        if (points.capacity() > 0) nbody::TrailPool::Release(std::move(points));
+    }
 };
 
 // Selection and interaction components

--- a/src/core/TrailPool.hpp
+++ b/src/core/TrailPool.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <raylib-cpp.hpp>
+#include <vector>
+
+#include "Constants.hpp"
+
+namespace nbody {
+
+    class TrailPool {
+    public:
+        static std::vector<raylib::Vector2> Acquire() {
+            auto& pool = get_pool();
+            if (!pool.empty()) {
+                auto pts = std::move(pool.back());
+                pool.pop_back();
+                pts.clear();
+                return pts;
+            }
+            std::vector<raylib::Vector2> pts;
+            pts.reserve(constants::trailLengthMax);
+            return pts;
+        }
+
+        static void Release(std::vector<raylib::Vector2>&& pts) {
+            pts.clear();
+            get_pool().push_back(std::move(pts));
+        }
+
+    private:
+        static std::vector<std::vector<raylib::Vector2>>& get_pool() {
+            static std::vector<std::vector<raylib::Vector2>> pool;
+            return pool;
+        }
+    };
+
+}  // namespace nbody

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 #include "components/Components.hpp"
 #include "core/Config.hpp"
 #include "core/Constants.hpp"
+#include "core/TrailPool.hpp"
 
 // New header-only systems
 #include "systems/Camera.hpp"
@@ -31,7 +32,7 @@ namespace scenario {
                 .set<Mass>({mass})
                 .set<Pinned>({pinned})
                 .set<Tint>({col})
-                .set<Trail>({{}})
+                .set<Trail>({nbody::TrailPool::Acquire()})
                 .add<Selectable>()  // Make all bodies selectable
                 .set<Draggable>({true, nbody::constants::dragVelScale});  // Make all bodies draggable
         };

--- a/src/systems/UI.hpp
+++ b/src/systems/UI.hpp
@@ -14,6 +14,7 @@
 #include "../components/Components.hpp"
 #include "../core/Config.hpp"
 #include "../core/Constants.hpp"
+#include "../core/TrailPool.hpp"
 #include "Camera.hpp"
 #include "Interaction.hpp"
 
@@ -137,7 +138,7 @@ namespace nbody {
                     .set<Mass>({std::max(nbody::constants::spawnMassMin, spawnMass)})
                     .set<Pinned>({spawnPinned})
                     .set<Tint>({RandomNiceColor()})
-                    .set<Trail>({{}})
+                    .set<Trail>({nbody::TrailPool::Acquire()})
                     .add<Selectable>()
                     .set<Draggable>({true, dragVelScale});
             }
@@ -226,7 +227,7 @@ namespace nbody {
                             .set(m)
                             .set(pin)
                             .set(t)
-                            .set(Trail{{}})
+                            .set(Trail{nbody::TrailPool::Acquire()})
                             .add<Selectable>()
                             .set<Draggable>({true, dragVelScale});
                     }
@@ -293,7 +294,7 @@ namespace nbody {
                     .set<Mass>({mass})
                     .set<Pinned>({pinned})
                     .set<Tint>({col})
-                    .set<Trail>({{}})
+                    .set<Trail>({nbody::TrailPool::Acquire()})
                     .add<Selectable>()
                     .set<Draggable>({true, nbody::constants::dragVelScale});
             };


### PR DESCRIPTION
## Summary
- add simple pool for Trail vectors
- use pooled vectors when creating bodies
- recycle Trail memory when trails disabled

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build -j`
- `./build/raylib_nbody` *(fails: glfwGetWindowContentScale assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a273a4e08329aeff57a2b6dbf5bb