### PR TITLE
physics: derive seed velocities from config

### DIFF
--- a/src/systems/Physics.hpp
+++ b/src/systems/Physics.hpp
@@ -64,6 +64,7 @@ public:
     }
 
     static void ResetScenario(const flecs::world& w) {
+        const Config& cfg = *w.get<Config>();
         std::vector<flecs::entity> toDel;
         w.each([&](const flecs::entity e, Position&) { toDel.push_back(e); });
         for (auto& e : toDel) e.destruct();
@@ -82,10 +83,12 @@ public:
                 .set<Draggable>({true, constants::dragVelScale});
         };
         mk({constants::seedCenterX, constants::seedCenterY}, {0.0f, 0.0f}, constants::seedCentralMass, RED, false);
-        mk({constants::seedCenterX + constants::seedOffsetX, constants::seedCenterY}, {0.0f, constants::seedSpeed},
-           constants::seedSmallMass, BLUE, false);
-        mk({constants::seedCenterX - constants::seedOffsetX, constants::seedCenterY}, {0.0f, -constants::seedSpeed},
-           constants::seedSmallMass, GREEN, false);
+        const float radius = constants::seedOffsetX;
+        const float v = std::sqrt(static_cast<float>(cfg.G) * constants::seedCentralMass / radius);
+        mk({constants::seedCenterX + radius, constants::seedCenterY}, {0.0f, v}, constants::seedSmallMass, BLUE, false);
+        mk({constants::seedCenterX - radius, constants::seedCenterY}, {0.0f, -v}, constants::seedSmallMass, GREEN,
+           false);
+        ZeroNetMomentum(w);
     }
 
     static bool ComputeDiagnostics(const flecs::world& w, const double G, const double eps2, Diagnostics& out) {


### PR DESCRIPTION
## Summary
- compute seed orbital velocities using current G and central mass
- offset small bodies with zero net momentum to reduce drift

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build -j`
- `./build/raylib_nbody` *(fails: glfwGetWindowContentScale assertion `window != NULL`)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cb90dee083299acfc2db71d47e1a