### PR TITLE
physics: ignore pinned bodies in momentum reset

### DIFF
--- a/src/systems/Physics.hpp
+++ b/src/systems/Physics.hpp
@@ -51,7 +51,11 @@ public:
 
     static void ZeroNetMomentum(const flecs::world& w) {
         double Px = 0.0, Py = 0.0, M = 0.0;
-        w.each([&](const Mass& m, const Velocity& v) {
+        w.each([&](const Mass& m, Velocity& v, const Pinned& pin) {
+            if (pin.value) {
+                v.value = raylib::Vector2{0, 0};
+                return;
+            }
             Px += static_cast<double>(m.value) * static_cast<double>(v.value.x);
             Py += static_cast<double>(m.value) * static_cast<double>(v.value.y);
             M += static_cast<double>(m.value);


### PR DESCRIPTION
## Summary
- skip pinned entities when computing total momentum and mass
- zero velocities for pinned anchors to keep them stationary

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build -j`
- `./build/raylib_nbody` *(fails: X11 DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d15a6f7c8329aa32852ba056ea43