### PR TITLE
Use SI units and realistic ranges

### DIFF
--- a/src/core/Config.hpp
+++ b/src/core/Config.hpp
@@ -5,10 +5,12 @@
 #include <raylib-cpp.hpp>
 
 // Global/singleton simulation configuration stored in flecs as a singleton component.
+// All physics values use SI units (meters, kilograms, seconds).
 struct Config {
     // Physics
-    double G = 6.67430e-3;
-    float softening = 4.0f;  // epsilon
+    double G = 6.67430e-11;  // gravitational constant (m^3 kg^-1 s^-2)
+    double meterToPixel = 1e-6;  // display scale: meters -> pixels
+    float softening = 4.0f;  // epsilon (m)
     float maxSpeed = 0.0f;  // 0 = uncapped
     int bhThreshold = 100;  // use Barnes-Hut when entity count exceeds this
     float bhTheta = 0.5f;  // opening angle criterion

--- a/src/core/Constants.hpp
+++ b/src/core/Constants.hpp
@@ -11,7 +11,7 @@ inline constexpr ::Color background{10, 10, 14, 255};
 
 inline constexpr float pickRadiusPx = 24.0F;
 inline constexpr float selectThresholdSq = 9.0F;
-inline constexpr float dragVelScale = 0.01F;
+inline constexpr float dragVelScale = 100.0F;
 
 inline constexpr float dragLineWidth = 2.0F;
 inline constexpr float dragCircleRadius = 3.0F;
@@ -28,7 +28,7 @@ inline constexpr float accVectorScale = 500.0F;
 inline constexpr float minBodyRadius = 6.0F;
 inline constexpr float selectedCircleAlpha = 0.5F;
 
-inline constexpr float gridSpacing = 50.0F;
+inline constexpr float gridSpacing = 1.0e7F;
 inline constexpr float gridAxisEpsilon = 1e-4F;
 inline constexpr float gridStepsEpsilon = 1e-6F;
 inline constexpr ::Color gridColor{40, 40, 40, 255};
@@ -38,12 +38,11 @@ inline constexpr int trailAlphaMin = 20;
 inline constexpr int trailAlphaMax = 250;
 inline constexpr float trailAlphaRange = 230.0F;
 
-inline constexpr float seedSmallMass = 12.0F;
-inline constexpr float seedCentralMass = 4000.0F;
-inline constexpr float seedSpeed = 1.20F;
-inline constexpr float seedCenterX = 640.0F;
-inline constexpr float seedCenterY = 360.0F;
-inline constexpr float seedOffsetX = 200.0F;
+inline constexpr double seedSmallMass = 7.342e22;  // kg (Moon mass)
+inline constexpr double seedCentralMass = 5.972e24;  // kg (Earth mass)
+inline constexpr double seedCenterX = 0.0;
+inline constexpr double seedCenterY = 0.0;
+inline constexpr double seedOffsetX = 3.844e8;  // m (Earth-Moon distance)
 
 inline constexpr float zoomWheelScale = 0.1F;
 inline constexpr float minZoom = 0.05F;
@@ -54,23 +53,23 @@ inline constexpr float fixedDtMax = 0.05F;
 inline constexpr float timeScaleMin = 0.0F;
 inline constexpr float timeScaleMax = 10.0F;
 inline constexpr float gMin = 0.0F;
-inline constexpr float gMax = 0.02F;
+inline constexpr float gMax = 1e-9F;
 inline constexpr float softeningMin = 0.0F;
-inline constexpr float softeningMax = 20.0F;
+inline constexpr float softeningMax = 1e9F;
 inline constexpr float velocityCapMin = 0.0F;
-inline constexpr float velocityCapMax = 200.0F;
+inline constexpr float velocityCapMax = 1e6F;
 inline constexpr int trailLengthMax = 2000;
 
-inline constexpr float spawnMassMin = 1.0F;
-inline constexpr float spawnMassMax = 5000.0F;
-inline constexpr float spawnVelMin = -5.0F;
-inline constexpr float spawnVelMax = 5.0F;
-inline constexpr float dragVelScaleMin = 0.001F;
-inline constexpr float dragVelScaleMax = 0.2F;
-inline constexpr float selectedMassMin = 1.0F;
-inline constexpr float selectedMassMax = 10000.0F;
-inline constexpr float selectedVelMin = -200.0F;
-inline constexpr float selectedVelMax = 200.0F;
+inline constexpr float spawnMassMin = 1e20F;
+inline constexpr float spawnMassMax = 1e28F;
+inline constexpr float spawnVelMin = -1e4F;
+inline constexpr float spawnVelMax = 1e4F;
+inline constexpr float dragVelScaleMin = 1.0F;
+inline constexpr float dragVelScaleMax = 1000.0F;
+inline constexpr float selectedMassMin = 1e20F;
+inline constexpr float selectedMassMax = 1e30F;
+inline constexpr float selectedVelMin = -1e5F;
+inline constexpr float selectedVelMax = 1e5F;
 inline constexpr float duplicateOffsetX = 20.0F;
 
 inline constexpr int randomColorMin = 64;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,12 +36,19 @@ void CreateInitialBodies(const flecs::world& world) {
             .set<Draggable>({true, nbody::constants::dragVelScale});  // Make all bodies draggable
     };
 
-    mk({nbody::constants::seedCenterX, nbody::constants::seedCenterY}, {0.0f, 0.0f}, nbody::constants::seedCentralMass,
-       RED, false);
-    mk({nbody::constants::seedCenterX + nbody::constants::seedOffsetX, nbody::constants::seedCenterY},
-       {0.0f, nbody::constants::seedSpeed}, nbody::constants::seedSmallMass, BLUE, false);
-    mk({nbody::constants::seedCenterX - nbody::constants::seedOffsetX, nbody::constants::seedCenterY},
-       {0.0f, -nbody::constants::seedSpeed}, nbody::constants::seedSmallMass, GREEN, false);
+    mk({static_cast<float>(nbody::constants::seedCenterX), static_cast<float>(nbody::constants::seedCenterY)},
+       {0.0f, 0.0f}, static_cast<float>(nbody::constants::seedCentralMass), RED, false);
+
+    const Config* cfg = world.get<Config>();
+    const double radius = nbody::constants::seedOffsetX;
+    const float v = cfg ? static_cast<float>(std::sqrt(cfg->G * nbody::constants::seedCentralMass / radius)) : 0.0f;
+
+    mk({static_cast<float>(nbody::constants::seedCenterX + nbody::constants::seedOffsetX),
+        static_cast<float>(nbody::constants::seedCenterY)},
+       {0.0f, v}, static_cast<float>(nbody::constants::seedSmallMass), BLUE, false);
+    mk({static_cast<float>(nbody::constants::seedCenterX - nbody::constants::seedOffsetX),
+        static_cast<float>(nbody::constants::seedCenterY)},
+       {0.0f, -v}, static_cast<float>(nbody::constants::seedSmallMass), GREEN, false);
 }
 }  // namespace scenario
 

--- a/src/systems/Camera.hpp
+++ b/src/systems/Camera.hpp
@@ -6,64 +6,69 @@
 #include <raymath.h>
 
 #include "../components/Components.hpp"
+#include "../core/Config.hpp"
 #include "../core/Constants.hpp"
 
 namespace nbody {
 
-    // Wraps the simulation camera as a singleton component and provides helpers.
-    class Camera {
-    public:
-        static inline void Init(raylib::Camera2D& cam) {
-            constexpr float kHalf = 0.5F;
-            cam.zoom = 1.0F;
-            cam.offset = {static_cast<float>(GetScreenWidth()) * kHalf, static_cast<float>(GetScreenHeight()) * kHalf};
-            cam.target = {nbody::constants::seedCenterX, nbody::constants::seedCenterY};
-        }
+// Wraps the simulation camera as a singleton component and provides helpers.
+class Camera {
+public:
+    static inline void Init(raylib::Camera2D& cam) {
+        constexpr float kHalf = 0.5F;
+        cam.zoom = 1.0F;
+        cam.offset = {static_cast<float>(GetScreenWidth()) * kHalf, static_cast<float>(GetScreenHeight()) * kHalf};
+        cam.target = {static_cast<float>(nbody::constants::seedCenterX),
+                      static_cast<float>(nbody::constants::seedCenterY)};
+    }
 
-        static inline void ZoomAtMouse(raylib::Camera2D& cam, const float wheel) {
-            if (wheel == 0.0F) return;
-            const raylib::Vector2 mouse = GetMousePosition();
-            const raylib::Vector2 worldBefore = GetScreenToWorld2D(mouse, cam);
-            const float newZoom = std::clamp(cam.zoom * (1.0F + wheel * nbody::constants::zoomWheelScale),
-                                             nbody::constants::minZoom, nbody::constants::maxZoom);
-            cam.zoom = newZoom;
-            const raylib::Vector2 worldAfter = GetScreenToWorld2D(mouse, cam);
-            cam.target = Vector2Add(cam.target, Vector2Subtract(worldBefore, worldAfter));
-        }
+    static inline void ZoomAtMouse(raylib::Camera2D& cam, const float wheel) {
+        if (wheel == 0.0F) return;
+        const raylib::Vector2 mouse = GetMousePosition();
+        const raylib::Vector2 worldBefore = GetScreenToWorld2D(mouse, cam);
+        const float newZoom = std::clamp(cam.zoom * (1.0F + wheel * nbody::constants::zoomWheelScale),
+                                         nbody::constants::minZoom, nbody::constants::maxZoom);
+        cam.zoom = newZoom;
+        const raylib::Vector2 worldAfter = GetScreenToWorld2D(mouse, cam);
+        cam.target = Vector2Add(cam.target, Vector2Subtract(worldBefore, worldAfter));
+    }
 
-        struct CameraComponent {
-            raylib::Camera2D camera;
-            CameraComponent() { Init(camera); }
-        };
-
-        static void Register(const flecs::world& world) {
-            world.set<CameraComponent>({});
-            CenterOnCenterOfMass(world);
-        }
-
-        static raylib::Camera2D* Get(const flecs::world& world) {
-            if (auto* cam = world.get_mut<CameraComponent>()) return &cam->camera;
-            return nullptr;
-        }
-
-        static void CenterOnCenterOfMass(const flecs::world& world) {
-            auto* camComp = world.get_mut<CameraComponent>();
-            if (!camComp) return;
-
-            double Cx = 0, Cy = 0, M = 0;
-            world.each([&](const Position& p, const Mass& m) {
-                Cx += static_cast<double>(m.value) * static_cast<double>(p.value.x);
-                Cy += static_cast<double>(m.value) * static_cast<double>(p.value.y);
-                M += static_cast<double>(m.value);
-            });
-            if (M > 0.0) camComp->camera.target = {static_cast<float>(Cx / M), static_cast<float>(Cy / M)};
-        }
-
-        static void FocusOnEntity(const flecs::world& world, flecs::entity entity) {
-            auto* camComp = world.get_mut<CameraComponent>();
-            if (!camComp) return;
-            if (const auto* pos = entity.get<Position>()) camComp->camera.target = pos->value;
-        }
+    struct CameraComponent {
+        raylib::Camera2D camera;
+        CameraComponent() { Init(camera); }
     };
+
+    static void Register(const flecs::world& world) {
+        world.set<CameraComponent>({});
+        if (auto* cam = world.get_mut<CameraComponent>()) {
+            if (const Config* cfg = world.get<Config>()) cam->camera.zoom = static_cast<float>(cfg->meterToPixel);
+        }
+        CenterOnCenterOfMass(world);
+    }
+
+    static raylib::Camera2D* Get(const flecs::world& world) {
+        if (auto* cam = world.get_mut<CameraComponent>()) return &cam->camera;
+        return nullptr;
+    }
+
+    static void CenterOnCenterOfMass(const flecs::world& world) {
+        auto* camComp = world.get_mut<CameraComponent>();
+        if (!camComp) return;
+
+        double Cx = 0, Cy = 0, M = 0;
+        world.each([&](const Position& p, const Mass& m) {
+            Cx += static_cast<double>(m.value) * static_cast<double>(p.value.x);
+            Cy += static_cast<double>(m.value) * static_cast<double>(p.value.y);
+            M += static_cast<double>(m.value);
+        });
+        if (M > 0.0) camComp->camera.target = {static_cast<float>(Cx / M), static_cast<float>(Cy / M)};
+    }
+
+    static void FocusOnEntity(const flecs::world& world, flecs::entity entity) {
+        auto* camComp = world.get_mut<CameraComponent>();
+        if (!camComp) return;
+        if (const auto* pos = entity.get<Position>()) camComp->camera.target = pos->value;
+    }
+};
 
 }  // namespace nbody

--- a/src/systems/Physics.hpp
+++ b/src/systems/Physics.hpp
@@ -86,12 +86,14 @@ public:
                 .add<Selectable>()
                 .set<Draggable>({true, constants::dragVelScale});
         };
-        mk({constants::seedCenterX, constants::seedCenterY}, {0.0f, 0.0f}, constants::seedCentralMass, RED, false);
-        const float radius = constants::seedOffsetX;
-        const float v = std::sqrt(static_cast<float>(cfg.G) * constants::seedCentralMass / radius);
-        mk({constants::seedCenterX + radius, constants::seedCenterY}, {0.0f, v}, constants::seedSmallMass, BLUE, false);
-        mk({constants::seedCenterX - radius, constants::seedCenterY}, {0.0f, -v}, constants::seedSmallMass, GREEN,
-           false);
+        mk({static_cast<float>(constants::seedCenterX), static_cast<float>(constants::seedCenterY)}, {0.0f, 0.0f},
+           static_cast<float>(constants::seedCentralMass), RED, false);
+        const double radius = constants::seedOffsetX;
+        const float v = static_cast<float>(std::sqrt(cfg.G * constants::seedCentralMass / radius));
+        mk({static_cast<float>(constants::seedCenterX + radius), static_cast<float>(constants::seedCenterY)}, {0.0f, v},
+           static_cast<float>(constants::seedSmallMass), BLUE, false);
+        mk({static_cast<float>(constants::seedCenterX - radius), static_cast<float>(constants::seedCenterY)},
+           {0.0f, -v}, static_cast<float>(constants::seedSmallMass), GREEN, false);
         ZeroNetMomentum(w);
     }
 

--- a/src/systems/UI.hpp
+++ b/src/systems/UI.hpp
@@ -78,12 +78,12 @@ private:
         ImGui::SetNextWindowSize(ImVec2(360, 0), ImGuiCond_FirstUseEver);
         ImGui::Begin("Physics");
         auto Gf = static_cast<float>(cfg.G);
-        ImGui::SliderFloat("G", &Gf, nbody::constants::gMin, nbody::constants::gMax, "%.6f");
+        ImGui::SliderFloat("G", &Gf, nbody::constants::gMin, nbody::constants::gMax, "%.2e");
         cfg.G = Gf;
         ImGui::SliderFloat("Softening (epsilon)", &cfg.softening, nbody::constants::softeningMin,
-                           nbody::constants::softeningMax, "%.3f");
+                           nbody::constants::softeningMax, "%.2e");
         ImGui::SliderFloat("Velocity Cap", &cfg.maxSpeed, nbody::constants::velocityCapMin,
-                           nbody::constants::velocityCapMax, "%.1f");
+                           nbody::constants::velocityCapMax, "%.0f");
         if (ImGui::Button("Zero Net Momentum")) Physics::ZeroNetMomentum(w);
         ImGui::SameLine();
         if (ImGui::Button("Reset Scenario")) {
@@ -109,16 +109,16 @@ private:
     }
 
     static void DrawAddEditPanel(const flecs::world& w, raylib::Camera2D& cam, float& dragVelScale) {
-        static float spawnMass = nbody::constants::seedSmallMass;
+        static float spawnMass = static_cast<float>(nbody::constants::seedSmallMass);
         static raylib::Vector2 spawnVel{0, 0};
         static bool spawnPinned = false;
         ImGui::SetNextWindowPos(ImVec2(12, 420), ImGuiCond_FirstUseEver);
         ImGui::SetNextWindowSize(ImVec2(380, 0), ImGuiCond_FirstUseEver);
         ImGui::Begin("Add / Edit");
         ImGui::SliderFloat("Spawn Mass", &spawnMass, nbody::constants::spawnMassMin, nbody::constants::spawnMassMax,
-                           "%.1f");
+                           "%.2e");
         ImGui::SliderFloat2("Spawn Velocity", &spawnVel.x, nbody::constants::spawnVelMin, nbody::constants::spawnVelMax,
-                            "%.3f");
+                            "%.1f");
         ImGui::Checkbox("Spawn Pinned", &spawnPinned);
         if (ImGui::Button("Add Body At Mouse")) {
             const raylib::Vector2 mouseWorld = GetScreenToWorld2D(GetMousePosition(), cam);
@@ -135,7 +135,7 @@ private:
                 .set<Draggable>({true, dragVelScale});
         }
         ImGui::SliderFloat("Right-Drag Vel Scale", &dragVelScale, nbody::constants::dragVelScaleMin,
-                           nbody::constants::dragVelScaleMax, "%.3f");
+                           nbody::constants::dragVelScaleMax, "%.1f");
 
         if (flecs::entity selected = Interaction::GetSelected(w); selected.is_alive()) {
             const auto mass = selected.get_mut<Mass>();
@@ -145,9 +145,9 @@ private:
                 ImGui::Text("Entity: %lld", static_cast<long long>(selected.id()));
                 ImGui::Checkbox("Pinned", &pin->value);
                 ImGui::SliderFloat("Mass", &mass->value, nbody::constants::selectedMassMin,
-                                   nbody::constants::selectedMassMax, "%.1f");
+                                   nbody::constants::selectedMassMax, "%.2e");
                 ImGui::SliderFloat2("Velocity", &vel->value.x, nbody::constants::selectedVelMin,
-                                    nbody::constants::selectedVelMax, "%.3f");
+                                    nbody::constants::selectedVelMax, "%.1f");
                 if (ImGui::Button("Zero Velocity")) vel->value = raylib::Vector2{0.0f, 0.0f};
                 ImGui::SameLine();
                 if (ImGui::Button("Remove Body")) {
@@ -194,7 +194,7 @@ private:
                 ImGui::SameLine();
                 if (ImGui::Selectable(("Entity " + std::to_string(e.id())).c_str(), isSel)) pendingSelection = e;
                 ImGui::SameLine();
-                ImGui::Text("pos(%.1f, %.1f) m=%.1f", p->value.x, p->value.y, m->value);
+                ImGui::Text("pos(%.2e, %.2e) m=%.2e", p->value.x, p->value.y, m->value);
                 ImGui::PopID();
             }
         }


### PR DESCRIPTION
## Summary
- switch simulation to SI units with true gravitational constant and display scaling
- seed Earth-Moon-like scenario with realistic masses and distances
- expose wider, scientific-notation UI sliders for G, masses, and velocities

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build -j`
- `./build/raylib_nbody` *(fails: glfwGetWindowContentScale assertion, headless environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a3df4ecca883299a9246d423a92700