### PR TITLE
Improve velocity drag visuals and rendering order

### DIFF
--- a/src/systems/Interaction.hpp
+++ b/src/systems/Interaction.hpp
@@ -77,6 +77,12 @@ public:
         const auto* state = world.get<State>();
         if (!state) return;
         BeginMode2D(camera);
+        if (state->isDraggingVelocity) {
+            DrawLineEx(state->dragStartWorld, state->currentDragWorld, nbody::constants::dragLineWidth / camera.zoom,
+                       WHITE);
+            DrawCircleV(state->dragStartWorld, nbody::constants::dragCircleRadius / camera.zoom, WHITE);
+            DrawCircleV(state->currentDragWorld, nbody::constants::dragCircleRadius / camera.zoom, WHITE);
+        }
         if (state->selectedEntity.is_alive()) {
             const auto* pos = state->selectedEntity.get<Position>();
             const auto* mass = state->selectedEntity.get<Mass>();


### PR DESCRIPTION
## Summary
- show a preview line while dragging to set velocity
- draw smaller bodies above larger ones and scale velocity vectors by drag amount

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68a3e91c3b88832981666223f635d285