### PR TITLE
Address static analysis issues in physics and UI

### DIFF
--- a/src/physics/SpatialPartition.hpp
+++ b/src/physics/SpatialPartition.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <algorithm>
-#include <cmath>
-#include <memory>
 #include <array>
+#include <cmath>
+#include <limits>
+#include <memory>
 #include <raylib-cpp.hpp>
 #include <vector>
 
@@ -88,7 +89,8 @@ public:
             const double dx = static_cast<double>(node->com.x) - static_cast<double>(target.pos.x);
             const double dy = static_cast<double>(node->com.y) - static_cast<double>(target.pos.y);
             const double dist = std::sqrt((dx * dx) + (dy * dy));
-            if ((static_cast<double>(node->halfSize) * 2.0) / dist < theta) {
+            const double safeDist = std::max(dist, std::numeric_limits<double>::epsilon());
+            if ((static_cast<double>(node->halfSize) * 2.0) / safeDist < theta) {
                 const double r2 = (dx * dx) + (dy * dy) + eps2;
                 const double invR = 1.0 / std::sqrt(r2);
                 const double invR3 = invR * invR * invR;
@@ -178,7 +180,10 @@ private:
     void aggregate_mass_com_iterative() {
         if (!root) return;
         // Post-order traversal using an explicit stack
-        struct Frame { Node* node; bool visited; };
+        struct Frame {
+            Node* node;
+            bool visited;
+        };
         std::vector<Frame> stack;
         stack.reserve(128);
         stack.push_back(Frame{root.get(), false});

--- a/src/systems/Physics.hpp
+++ b/src/systems/Physics.hpp
@@ -29,6 +29,11 @@ public:
         bool ok = true;
     };
 
+    struct DiagnosticsParams {
+        double gravitationalConstant = 0.0;
+        double softeningSquared = 0.0;
+    };
+
     static void register_systems(const flecs::world& w) {
         // Collisions: resolve overlaps before computing forces.
         w.system<>().kind(flecs::OnUpdate).iter([&](flecs::iter&) {
@@ -36,8 +41,11 @@ public:
             if (!cfg || cfg->paused) return;
             nbody::systems::Collision::resolve(w);
             Diagnostics d{};
-            d.ok = compute_diagnostics(w, cfg->g,
-                                       static_cast<double>(cfg->softening) * static_cast<double>(cfg->softening), d);
+            const DiagnosticsParams params{
+                .gravitationalConstant = cfg->g,
+                .softeningSquared = static_cast<double>(cfg->softening) * static_cast<double>(cfg->softening),
+            };
+            d.ok = compute_diagnostics(w, params, d);
             w.set<Diagnostics>(d);
         });
 
@@ -114,7 +122,9 @@ public:
         zero_net_momentum(w);
     }
 
-    static bool compute_diagnostics(const flecs::world& w, const double G, const double eps2, Diagnostics& out) {
+    static bool compute_diagnostics(const flecs::world& w, const DiagnosticsParams& params, Diagnostics& out) {
+        const double G = params.gravitationalConstant;
+        const double eps2 = params.softeningSquared;
         std::vector<std::tuple<DVec2, DVec2, float>> data;
         data.reserve(1024);
         w.each(
@@ -178,8 +188,6 @@ public:
     // No backward-compatible aliases: use snake_case API
 
 private:
-    static inline bool is_finite(const float v) { return std::isfinite(static_cast<double>(v)); }
-
     static void compute_gravity(const flecs::world& w) {
         const Config& cfg = *w.get<Config>();
         const double G = cfg.g;

--- a/src/systems/UI.hpp
+++ b/src/systems/UI.hpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cfloat>
 #include <cmath>
+#include <cstddef>
 #include <flecs.h>
 #include <imgui.h>
 #include <raylib-cpp.hpp>
@@ -246,10 +247,11 @@ private:
                 const bool isSel =
                     (Interaction::get_selected(w).is_alive() && Interaction::get_selected(w).id() == e.id());
                 ImGui::PushID(static_cast<int>(e.id()));
+                const float maxColorComponent = static_cast<float>(nbody::constants::random_color_max);
                 ImGui::ColorButton("##c",
-                                   ImVec4(t->value.r / static_cast<float>(nbody::constants::random_color_max),
-                                          t->value.g / static_cast<float>(nbody::constants::random_color_max),
-                                          t->value.b / static_cast<float>(nbody::constants::random_color_max), 1.0f),
+                                   ImVec4(static_cast<float>(t->value.r) / maxColorComponent,
+                                          static_cast<float>(t->value.g) / maxColorComponent,
+                                          static_cast<float>(t->value.b) / maxColorComponent, 1.0f),
                                    0, ImVec2(16, 16));
                 ImGui::SameLine();
                 if (ImGui::Selectable(("Entity " + std::to_string(e.id())).c_str(), isSel)) pendingSelection = e;
@@ -298,8 +300,11 @@ private:
         if (const auto* dp = w.get<Physics::Diagnostics>()) {
             d = *dp;
         } else {
-            d.ok = Physics::compute_diagnostics(
-                w, cfg.g, static_cast<double>(cfg.softening) * static_cast<double>(cfg.softening), d);
+            const Physics::DiagnosticsParams params{
+                .gravitationalConstant = cfg.g,
+                .softeningSquared = static_cast<double>(cfg.softening) * static_cast<double>(cfg.softening),
+            };
+            d.ok = Physics::compute_diagnostics(w, params, d);
         }
         ImGui::SetNextWindowPos(ImVec2(400, 390), ImGuiCond_FirstUseEver);
         ImGui::SetNextWindowSize(ImVec2(380, 0), ImGuiCond_FirstUseEver);
@@ -355,9 +360,11 @@ private:
             store->selected = static_cast<int>(store->items.size()) - 1;
         }
         ImGui::SameLine();
-        const bool canSel = (store->selected >= 0 && store->selected < (int)store->items.size());
-        if (ImGui::Button("Overwrite Selected") && canSel) {
-            const std::string name = (nameBuf[0] != '\0') ? std::string(nameBuf) : store->items[store->selected].name;
+        const bool hasSelection =
+            store->selected >= 0 && static_cast<std::size_t>(store->selected) < store->items.size();
+        if (ImGui::Button("Overwrite Selected") && hasSelection) {
+            const std::size_t selectedIndex = static_cast<std::size_t>(store->selected);
+            const std::string name = (nameBuf[0] != '\0') ? std::string(nameBuf) : store->items[selectedIndex].name;
             const std::string desc = std::string(descBuf);
             Scenario s = snapshot_from_world(w, name, desc);
             // use current tagsBuf
@@ -373,7 +380,7 @@ private:
                 if (comma == std::string::npos) break;
                 start = comma + 1;
             }
-            store->items[store->selected] = std::move(s);
+            store->items[selectedIndex] = std::move(s);
         }
 
         ImGui::Separator();
@@ -384,7 +391,7 @@ private:
         ImGui::BeginChild("##ScenarioList", ImVec2(0, 140), true);
         for (int i = 0; i < static_cast<int>(store->items.size()); ++i) {
             const bool selected = (store->selected == i);
-            const auto& s = store->items[i];
+            const auto& s = store->items[static_cast<std::size_t>(i)];
             // If filter present, skip items that do not match name or any tag
             if (!filterStr.empty()) {
                 bool match = s.name.find(filterStr) != std::string::npos;
@@ -434,20 +441,21 @@ private:
         }
         ImGui::EndChild();
 
-        const bool canAct = canSel;
         ImGui::Checkbox("Apply Config on Load", &applyConfigOnLoad);
-        if (ImGui::Button("Load Selected") && canAct) {
+        if (ImGui::Button("Load Selected") && hasSelection) {
+            const std::size_t selectedIndex = static_cast<std::size_t>(store->selected);
             if (applyConfigOnLoad) {
-                apply_scenario_to_world(w, store->items[store->selected]);
+                apply_scenario_to_world(w, store->items[selectedIndex]);
             } else {
-                apply_scenario_bodies_only(w, store->items[store->selected]);
+                apply_scenario_bodies_only(w, store->items[selectedIndex]);
             }
             // Reset camera for a clean view
             Camera::reset_view(w);
         }
         ImGui::SameLine();
-        if (ImGui::Button("Delete Selected") && canAct) {
-            store->items.erase(store->items.begin() + store->selected);
+        if (ImGui::Button("Delete Selected") && hasSelection) {
+            const std::size_t selectedIndex = static_cast<std::size_t>(store->selected);
+            store->items.erase(store->items.begin() + static_cast<std::ptrdiff_t>(selectedIndex));
             store->selected = -1;
         }
 


### PR DESCRIPTION
## Summary
- guard the Barnes-Hut tree acceptance criterion against zero-distance division
- wrap physics diagnostics arguments in a struct and reuse them from the UI fallback path
- harden scenario UI index handling and color conversions flagged by static analysis

## Testing
- cmake --build build -j

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69153a62a5fc8329b28c414becb4c922)